### PR TITLE
feat: add EcoleDirecte API example with Node.js and Hono

### DIFF
--- a/exemple/node_hono/.gitignore
+++ b/exemple/node_hono/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+test.js
+testHono.ts
+src/config/qcm.ts

--- a/exemple/node_hono/README.MD
+++ b/exemple/node_hono/README.MD
@@ -1,0 +1,132 @@
+# Exemple d'API EcoleDirecte avec Node.js et Hono
+
+## Description
+
+Ce projet est un exemple d'implémentation d'une API REST pour interagir avec l'API EcoleDirecte. Il utilise Node.js avec TypeScript et le framework Hono pour créer une API légère et performante qui permet de :
+
+- S'authentifier à EcoleDirecte (y compris la gestion automatique des QCM de sécurité)
+- Récupérer le cahier de texte et les devoirs des élèves
+- Gérer correctement les tokens et cookies nécessaires pour l'authentification
+
+## Prérequis
+
+- Node.js (v18 ou supérieur recommandé)
+- pnpm (ou npm/yarn)
+
+## Installation
+
+1. Clonez ce dépôt
+2. Installez les dépendances :
+   ```bash
+   pnpm install
+   ```
+3. Créez un fichier de configuration pour les QCM :
+   ```bash
+   cp src/config/qcm.exemple.ts src/config/qcm.ts
+   ```
+4. Modifiez le fichier `src/config/qcm.ts` pour ajouter vos réponses aux questions QCM. Vous pouvez vous baser sur le fichier exemple fourni (`qcm.exemple.ts`) qui contient déjà la structure nécessaire.
+
+## Démarrage
+
+Pour lancer le serveur en mode développement :
+
+```bash
+pnpm dev
+```
+
+Le serveur démarre sur http://localhost:3000
+
+## Structure du projet
+
+```
+src/
+├── config/           # Configuration de l'API
+│   ├── constants.ts  # URLs et paramètres de l'API
+│   ├── qcm.exemple.ts# Exemple de configuration des QCM
+│   └── qcm.ts        # Configuration des QCM (à créer)
+├── routes/           # Routes de l'API
+│   └── ecoledirecte.ts # Routes pour interagir avec EcoleDirecte
+├── services/         # Services métier
+│   └── ecoledirecte.service.ts # Service d'interaction avec l'API EcoleDirecte
+├── types/            # Définitions de types TypeScript
+│   └── ecoleDirecte.ts # Types pour les requêtes/réponses EcoleDirecte
+├── utils/            # Utilitaires
+│   ├── auth.ts       # Gestion des en-têtes d'authentification
+│   ├── base64.ts     # Encodage/décodage Base64
+│   ├── cookies.ts    # Extraction et gestion des cookies
+│   ├── qcm.ts        # Aide à la résolution des QCM
+│   └── url.ts        # Construction des URLs d'API
+└── index.ts          # Point d'entrée de l'application
+```
+
+## Fonctionnalités principales
+
+### Authentification avec gestion automatique des QCM
+
+L'API gère automatiquement :
+
+- L'obtention du token GTK initial
+- La tentative de connexion
+- Si un QCM est requis :
+  - Récupération du QCM
+  - Recherche de la réponse dans la base de connaissances configurée
+  - Envoi de la réponse au QCM
+  - Nouvelle authentification avec les données du QCM
+
+### Récupération du cahier de texte
+
+L'API permet de :
+
+- Récupérer l'ensemble des devoirs à faire
+- Récupérer les devoirs pour une date spécifique
+
+## Utilisation de l'API
+
+### Authentification
+
+```
+POST /ecoledirecte/login
+Content-Type: application/json
+
+{
+  "username": "votre_identifiant",
+  "password": "votre_mot_de_passe"
+}
+```
+
+Réponse :
+
+```json
+{
+  "success": true,
+  "token": "token_ecoledirecte",
+  "accounts": [...],
+  "autoQcmAnswered": true  // Si un QCM a été résolu automatiquement
+}
+```
+
+### Récupération des devoirs
+
+```
+GET /ecoledirecte/assignments/{studentId}
+Authorization: token_ecoledirecte
+```
+
+### Récupération des devoirs pour une date spécifique
+
+```
+GET /ecoledirecte/assignments/{studentId}/{date}
+Authorization: token_ecoledirecte
+```
+
+## Configuration des QCM
+
+Pour configurer les réponses aux QCM, créer un fichier `src/config/qcm.ts` en ajoutant les paires question/réponse. Un exemple est fourni dans `qcm.exemple.ts` :
+
+```typescript
+export const QCM_ANSWERS: QcmAnswersType = {
+  "Quelle est votre année de naissance ?": "2006",
+  "Quel est votre mois de naissance ?": "janvier",
+  // Ajoutez vos réponses ici
+};
+```

--- a/exemple/node_hono/package.json
+++ b/exemple/node_hono/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "ecoledirecte-api-docs",
+  "version": "1.0.0",
+  "type": "module",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "dev": "tsx watch src/index.ts",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "packageManager": "pnpm@10.8.0",
+  "dependencies": {
+    "@hono/node-server": "^1.14.1",
+    "hono": "^4.7.6"
+  },
+  "devDependencies": {
+    "@types/node": "^22.14.1",
+    "ts-node": "^10.9.2",
+    "tsx": "^4.19.3",
+    "typescript": "^5.8.3"
+  }
+}

--- a/exemple/node_hono/pnpm-lock.yaml
+++ b/exemple/node_hono/pnpm-lock.yaml
@@ -1,0 +1,484 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@hono/node-server':
+        specifier: ^1.14.1
+        version: 1.14.1(hono@4.7.6)
+      hono:
+        specifier: ^4.7.6
+        version: 4.7.6
+    devDependencies:
+      '@types/node':
+        specifier: ^22.14.1
+        version: 22.14.1
+      ts-node:
+        specifier: ^10.9.2
+        version: 10.9.2(@types/node@22.14.1)(typescript@5.8.3)
+      tsx:
+        specifier: ^4.19.3
+        version: 4.19.3
+      typescript:
+        specifier: ^5.8.3
+        version: 5.8.3
+
+packages:
+
+  '@cspotcode/source-map-support@0.8.1':
+    resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
+    engines: {node: '>=12'}
+
+  '@esbuild/aix-ppc64@0.25.2':
+    resolution: {integrity: sha512-wCIboOL2yXZym2cgm6mlA742s9QeJ8DjGVaL39dLN4rRwrOgOyYSnOaFPhKZGLb2ngj4EyfAFjsNJwPXZvseag==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.25.2':
+    resolution: {integrity: sha512-5ZAX5xOmTligeBaeNEPnPaeEuah53Id2tX4c2CVP3JaROTH+j4fnfHCkr1PjXMd78hMst+TlkfKcW/DlTq0i4w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.2':
+    resolution: {integrity: sha512-NQhH7jFstVY5x8CKbcfa166GoV0EFkaPkCKBQkdPJFvo5u+nGXLEH/ooniLb3QI8Fk58YAx7nsPLozUWfCBOJA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.25.2':
+    resolution: {integrity: sha512-Ffcx+nnma8Sge4jzddPHCZVRvIfQ0kMsUsCMcJRHkGJ1cDmhe4SsrYIjLUKn1xpHZybmOqCWwB0zQvsjdEHtkg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.25.2':
+    resolution: {integrity: sha512-MpM6LUVTXAzOvN4KbjzU/q5smzryuoNjlriAIx+06RpecwCkL9JpenNzpKd2YMzLJFOdPqBpuub6eVRP5IgiSA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.2':
+    resolution: {integrity: sha512-5eRPrTX7wFyuWe8FqEFPG2cU0+butQQVNcT4sVipqjLYQjjh8a8+vUTfgBKM88ObB85ahsnTwF7PSIt6PG+QkA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.25.2':
+    resolution: {integrity: sha512-mLwm4vXKiQ2UTSX4+ImyiPdiHjiZhIaE9QvC7sw0tZ6HoNMjYAqQpGyui5VRIi5sGd+uWq940gdCbY3VLvsO1w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.2':
+    resolution: {integrity: sha512-6qyyn6TjayJSwGpm8J9QYYGQcRgc90nmfdUb0O7pp1s4lTY+9D0H9O02v5JqGApUyiHOtkz6+1hZNvNtEhbwRQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.25.2':
+    resolution: {integrity: sha512-gq/sjLsOyMT19I8obBISvhoYiZIAaGF8JpeXu1u8yPv8BE5HlWYobmlsfijFIZ9hIVGYkbdFhEqC0NvM4kNO0g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.2':
+    resolution: {integrity: sha512-UHBRgJcmjJv5oeQF8EpTRZs/1knq6loLxTsjc3nxO9eXAPDLcWW55flrMVc97qFPbmZP31ta1AZVUKQzKTzb0g==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.25.2':
+    resolution: {integrity: sha512-bBYCv9obgW2cBP+2ZWfjYTU+f5cxRoGGQ5SeDbYdFCAZpYWrfjjfYwvUpP8MlKbP0nwZ5gyOU/0aUzZ5HWPuvQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.2':
+    resolution: {integrity: sha512-SHNGiKtvnU2dBlM5D8CXRFdd+6etgZ9dXfaPCeJtz+37PIUlixvlIhI23L5khKXs3DIzAn9V8v+qb1TRKrgT5w==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.25.2':
+    resolution: {integrity: sha512-hDDRlzE6rPeoj+5fsADqdUZl1OzqDYow4TB4Y/3PlKBD0ph1e6uPHzIQcv2Z65u2K0kpeByIyAjCmjn1hJgG0Q==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.2':
+    resolution: {integrity: sha512-tsHu2RRSWzipmUi9UBDEzc0nLc4HtpZEI5Ba+Omms5456x5WaNuiG3u7xh5AO6sipnJ9r4cRWQB2tUjPyIkc6g==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.25.2':
+    resolution: {integrity: sha512-k4LtpgV7NJQOml/10uPU0s4SAXGnowi5qBSjaLWMojNCUICNu7TshqHLAEbkBdAszL5TabfvQ48kK84hyFzjnw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.2':
+    resolution: {integrity: sha512-GRa4IshOdvKY7M/rDpRR3gkiTNp34M0eLTaC1a08gNrh4u488aPhuZOCpkF6+2wl3zAN7L7XIpOFBhnaE3/Q8Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.25.2':
+    resolution: {integrity: sha512-QInHERlqpTTZ4FRB0fROQWXcYRD64lAoiegezDunLpalZMjcUcld3YzZmVJ2H/Cp0wJRZ8Xtjtj0cEHhYc/uUg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.25.2':
+    resolution: {integrity: sha512-talAIBoY5M8vHc6EeI2WW9d/CkiO9MQJ0IOWX8hrLhxGbro/vBXJvaQXefW2cP0z0nQVTdQ/eNyGFV1GSKrxfw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.2':
+    resolution: {integrity: sha512-voZT9Z+tpOxrvfKFyfDYPc4DO4rk06qamv1a/fkuzHpiVBMOhpjK+vBmWM8J1eiB3OLSMFYNaOaBNLXGChf5tg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.25.2':
+    resolution: {integrity: sha512-dcXYOC6NXOqcykeDlwId9kB6OkPUxOEqU+rkrYVqJbK2hagWOMrsTGsMr8+rW02M+d5Op5NNlgMmjzecaRf7Tg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.2':
+    resolution: {integrity: sha512-t/TkWwahkH0Tsgoq1Ju7QfgGhArkGLkF1uYz8nQS/PPFlXbP5YgRpqQR3ARRiC2iXoLTWFxc6DJMSK10dVXluw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/sunos-x64@0.25.2':
+    resolution: {integrity: sha512-cfZH1co2+imVdWCjd+D1gf9NjkchVhhdpgb1q5y6Hcv9TP6Zi9ZG/beI3ig8TvwT9lH9dlxLq5MQBBgwuj4xvA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.25.2':
+    resolution: {integrity: sha512-7Loyjh+D/Nx/sOTzV8vfbB3GJuHdOQyrOryFdZvPHLf42Tk9ivBU5Aedi7iyX+x6rbn2Mh68T4qq1SDqJBQO5Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.25.2':
+    resolution: {integrity: sha512-WRJgsz9un0nqZJ4MfhabxaD9Ft8KioqU3JMinOTvobbX6MOSUigSBlogP8QB3uxpJDsFS6yN+3FDBdqE5lg9kg==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.2':
+    resolution: {integrity: sha512-kM3HKb16VIXZyIeVrM1ygYmZBKybX8N4p754bw390wGO3Tf2j4L2/WYL+4suWujpgf6GBYs3jv7TyUivdd05JA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@hono/node-server@1.14.1':
+    resolution: {integrity: sha512-vmbuM+HPinjWzPe7FFPWMMQMsbKE9gDPhaH0FFdqbGpkT5lp++tcWDTxwBl5EgS5y6JVgIaCdjeHRfQ4XRBRjQ==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.0':
+    resolution: {integrity: sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
+
+  '@tsconfig/node10@1.0.11':
+    resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
+
+  '@tsconfig/node12@1.0.11':
+    resolution: {integrity: sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==}
+
+  '@tsconfig/node14@1.0.3':
+    resolution: {integrity: sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==}
+
+  '@tsconfig/node16@1.0.4':
+    resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/node@22.14.1':
+    resolution: {integrity: sha512-u0HuPQwe/dHrItgHHpmw3N2fYCR6x4ivMNbPHRkBVP4CvN+kiRrKHWk3i8tXiO/joPwXLMYvF9TTF0eqgHIuOw==}
+
+  acorn-walk@8.3.4:
+    resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
+    engines: {node: '>=0.4.0'}
+
+  acorn@8.14.1:
+    resolution: {integrity: sha512-OvQ/2pUDKmgfCg++xsTX1wGxfTaszcHVcTctW4UJB4hibJx2HXxxO5UmVgyjMa+ZDsiaf5wWLXYpRWMmBI0QHg==}
+    engines: {node: '>=0.4.0'}
+    hasBin: true
+
+  arg@4.1.3:
+    resolution: {integrity: sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==}
+
+  create-require@1.1.1:
+    resolution: {integrity: sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==}
+
+  diff@4.0.2:
+    resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
+    engines: {node: '>=0.3.1'}
+
+  esbuild@0.25.2:
+    resolution: {integrity: sha512-16854zccKPnC+toMywC+uKNeYSv+/eXkevRAfwRD/G9Cleq66m8XFIrigkbvauLLlCfDL45Q2cWegSg53gGBnQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  get-tsconfig@4.10.0:
+    resolution: {integrity: sha512-kGzZ3LWWQcGIAmg6iWvXn0ei6WDtV26wzHRMwDSzmAbcXrTEXxHy6IehI6/4eT6VRKyMP1eF1VqwrVUmE/LR7A==}
+
+  hono@4.7.6:
+    resolution: {integrity: sha512-564rVzELU+9BRqqx5k8sT2NFwGD3I3Vifdb6P7CmM6FiarOSY+fDC+6B+k9wcCb86ReoayteZP2ki0cRLN1jbw==}
+    engines: {node: '>=16.9.0'}
+
+  make-error@1.3.6:
+    resolution: {integrity: sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==}
+
+  resolve-pkg-maps@1.0.0:
+    resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  ts-node@10.9.2:
+    resolution: {integrity: sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==}
+    hasBin: true
+    peerDependencies:
+      '@swc/core': '>=1.2.50'
+      '@swc/wasm': '>=1.2.50'
+      '@types/node': '*'
+      typescript: '>=2.7'
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      '@swc/wasm':
+        optional: true
+
+  tsx@4.19.3:
+    resolution: {integrity: sha512-4H8vUNGNjQ4V2EOoGw005+c+dGuPSnhpPBPHBtsZdGZBk/iJb4kguGlPWaZTZ3q5nMtFOEsY0nRDlh9PJyd6SQ==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  typescript@5.8.3:
+    resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  v8-compile-cache-lib@3.0.1:
+    resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
+
+  yn@3.1.1:
+    resolution: {integrity: sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==}
+    engines: {node: '>=6'}
+
+snapshots:
+
+  '@cspotcode/source-map-support@0.8.1':
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.9
+
+  '@esbuild/aix-ppc64@0.25.2':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/android-arm@0.25.2':
+    optional: true
+
+  '@esbuild/android-x64@0.25.2':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.2':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.2':
+    optional: true
+
+  '@esbuild/linux-ia32@0.25.2':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.25.2':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.25.2':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.2':
+    optional: true
+
+  '@esbuild/linux-x64@0.25.2':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.25.2':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.25.2':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.2':
+    optional: true
+
+  '@esbuild/win32-arm64@0.25.2':
+    optional: true
+
+  '@esbuild/win32-ia32@0.25.2':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.2':
+    optional: true
+
+  '@hono/node-server@1.14.1(hono@4.7.6)':
+    dependencies:
+      hono: 4.7.6
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.0': {}
+
+  '@jridgewell/trace-mapping@0.3.9':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.0
+
+  '@tsconfig/node10@1.0.11': {}
+
+  '@tsconfig/node12@1.0.11': {}
+
+  '@tsconfig/node14@1.0.3': {}
+
+  '@tsconfig/node16@1.0.4': {}
+
+  '@types/node@22.14.1':
+    dependencies:
+      undici-types: 6.21.0
+
+  acorn-walk@8.3.4:
+    dependencies:
+      acorn: 8.14.1
+
+  acorn@8.14.1: {}
+
+  arg@4.1.3: {}
+
+  create-require@1.1.1: {}
+
+  diff@4.0.2: {}
+
+  esbuild@0.25.2:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.2
+      '@esbuild/android-arm': 0.25.2
+      '@esbuild/android-arm64': 0.25.2
+      '@esbuild/android-x64': 0.25.2
+      '@esbuild/darwin-arm64': 0.25.2
+      '@esbuild/darwin-x64': 0.25.2
+      '@esbuild/freebsd-arm64': 0.25.2
+      '@esbuild/freebsd-x64': 0.25.2
+      '@esbuild/linux-arm': 0.25.2
+      '@esbuild/linux-arm64': 0.25.2
+      '@esbuild/linux-ia32': 0.25.2
+      '@esbuild/linux-loong64': 0.25.2
+      '@esbuild/linux-mips64el': 0.25.2
+      '@esbuild/linux-ppc64': 0.25.2
+      '@esbuild/linux-riscv64': 0.25.2
+      '@esbuild/linux-s390x': 0.25.2
+      '@esbuild/linux-x64': 0.25.2
+      '@esbuild/netbsd-arm64': 0.25.2
+      '@esbuild/netbsd-x64': 0.25.2
+      '@esbuild/openbsd-arm64': 0.25.2
+      '@esbuild/openbsd-x64': 0.25.2
+      '@esbuild/sunos-x64': 0.25.2
+      '@esbuild/win32-arm64': 0.25.2
+      '@esbuild/win32-ia32': 0.25.2
+      '@esbuild/win32-x64': 0.25.2
+
+  fsevents@2.3.3:
+    optional: true
+
+  get-tsconfig@4.10.0:
+    dependencies:
+      resolve-pkg-maps: 1.0.0
+
+  hono@4.7.6: {}
+
+  make-error@1.3.6: {}
+
+  resolve-pkg-maps@1.0.0: {}
+
+  ts-node@10.9.2(@types/node@22.14.1)(typescript@5.8.3):
+    dependencies:
+      '@cspotcode/source-map-support': 0.8.1
+      '@tsconfig/node10': 1.0.11
+      '@tsconfig/node12': 1.0.11
+      '@tsconfig/node14': 1.0.3
+      '@tsconfig/node16': 1.0.4
+      '@types/node': 22.14.1
+      acorn: 8.14.1
+      acorn-walk: 8.3.4
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      typescript: 5.8.3
+      v8-compile-cache-lib: 3.0.1
+      yn: 3.1.1
+
+  tsx@4.19.3:
+    dependencies:
+      esbuild: 0.25.2
+      get-tsconfig: 4.10.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  typescript@5.8.3: {}
+
+  undici-types@6.21.0: {}
+
+  v8-compile-cache-lib@3.0.1: {}
+
+  yn@3.1.1: {}

--- a/exemple/node_hono/src/config/constants.ts
+++ b/exemple/node_hono/src/config/constants.ts
@@ -1,0 +1,12 @@
+export const ECOLEDIRECTE_CONFIG = {
+  userAgent:
+    "Mozilla/5.0 (X11; Linux x86_64; rv:137.0) Gecko/20100101 Firefox/137.0",
+  apiVersion: "4.77.5",
+};
+export const ECOLEDIRECTE_URL = {
+  baseUrl: "https://api.ecoledirecte.com/v3/",
+  login: "login.awp",
+  doubleAuth: "connexion/doubleauth.awp",
+  cahierDeTexte: "Eleves/{eleveId}/cahierdetexte.awp",
+  cahierDeTexteDate: "Eleves/{eleveId}/cahierdetexte/{date}.awp",
+};

--- a/exemple/node_hono/src/config/qcm.exemple.ts
+++ b/exemple/node_hono/src/config/qcm.exemple.ts
@@ -1,0 +1,11 @@
+export type QcmAnswersType = {
+  [question: string]: string;
+};
+
+export const QCM_ANSWERS: QcmAnswersType = {
+  "Quelle est votre année de naissance ?": "",
+  "Quel est votre mois de naissance ?": "",
+  "Quelle est votre classe ?": "",
+  "Quel est votre jour de naissance ?": "",
+  "Quel est le nom de famille de votre professeur principal ?": "",
+};

--- a/exemple/node_hono/src/index.ts
+++ b/exemple/node_hono/src/index.ts
@@ -1,0 +1,16 @@
+import { serve } from "@hono/node-server";
+import { Hono } from "hono";
+import { logger } from "hono/logger";
+import ecoleDirecteRoutes from "./routes/ecoledirecte";
+
+const app = new Hono();
+
+app.use(logger());
+
+app.get("/", (c) => c.text("Hello Hono + TypeScript + pnpm"));
+app.route("/ecoledirecte", ecoleDirecteRoutes);
+const port = 3000;
+
+serve({ fetch: app.fetch, port }, () => {
+  console.log(`Listening on http://localhost:${port}`);
+});

--- a/exemple/node_hono/src/routes/ecoledirecte.ts
+++ b/exemple/node_hono/src/routes/ecoledirecte.ts
@@ -1,0 +1,167 @@
+import { Hono } from "hono";
+import { EcoleDirecteService } from "../services/ecoledirecte.service";
+import { decodeBase64 } from "../utils/base64";
+import { findAnswer } from "../utils/qcm";
+
+const ecoleDirecteRoutes = new Hono();
+const ecoleDirecteService = new EcoleDirecteService();
+
+// Authentication route with automatic QCM response
+ecoleDirecteRoutes.post("/login", async (c) => {
+  try {
+    const { username, password } = await c.req.json();
+    // Get the GTK, we need it only for the first login
+    const gtkData = await ecoleDirecteService.getGTK();
+
+    // Login attempt
+    const loginData = {
+      username,
+      password,
+      isReLogin: false,
+      uuid: "",
+    };
+
+    let loginResponse = await ecoleDirecteService.login(gtkData, loginData);
+
+    // If no double authentication is required, return success directly
+    if (loginResponse.code !== 250) {
+      return c.json({
+        success: true,
+        token: loginResponse.token,
+        accounts: loginResponse.data.accounts,
+      });
+    }
+
+    // Handle double authentication
+    console.log("QCM verification required");
+
+    // Get the QCM
+    const qcmJson = await ecoleDirecteService.getQCM(
+      gtkData,
+      loginResponse.token
+    );
+
+    // Decode the question and propositions
+    const questionBase64 = qcmJson.data.question;
+    const propositionsBase64 = qcmJson.data.propositions;
+    const question = decodeBase64(questionBase64);
+    const propositions = propositionsBase64.map((p) => decodeBase64(p));
+
+    // Search for the answer in our knowledge base
+    const autoAnswer = findAnswer(question);
+
+    // Error if no answer found in our knowledge base
+    if (!autoAnswer) {
+      // Unknown answer - error with details to add to configuration
+      return c.json({
+        code: 404,
+        message:
+          "Unknown QCM question - Please add this question to your configuration",
+        question,
+        propositions,
+        errorType: "unknown",
+        configFile: "src/config/qcm.ts",
+        configFormat: `"${question}": "YOUR_ANSWER"`,
+      });
+    }
+
+    // Find the index of the answer in the propositions
+    const answerIndex = propositions.findIndex(
+      (p) => p.toLowerCase().trim() === autoAnswer.toLowerCase().trim()
+    );
+
+    // Error if answer doesn't match any proposition
+    if (answerIndex === -1) {
+      // Known answer but doesn't match any proposition
+      return c.json({
+        code: 400,
+        message: "The automatic answer doesn't match any proposition",
+        question,
+        propositions,
+        knownAnswer: autoAnswer,
+        errorType: "mismatch",
+      });
+    }
+
+    // We have a valid answer, submit it
+    console.log(`Automatic answer found: "${autoAnswer}"`);
+    const choiceBase64 = propositionsBase64[answerIndex];
+
+    // Send the answer automatically
+    const qcmResult = await ecoleDirecteService.answerQCM(
+      gtkData,
+      loginResponse.token,
+      choiceBase64
+    );
+
+    // Get a new GTK and login with QCM data
+    const newGtkData = await ecoleDirecteService.getGTK();
+
+    const finalLoginData = {
+      username,
+      password,
+      isReLogin: false,
+      uuid: "",
+      fa: [{ cn: qcmResult.data.cn, cv: qcmResult.data.cv }],
+    };
+
+    // Final login
+    loginResponse = await ecoleDirecteService.login(newGtkData, finalLoginData);
+
+    return c.json({
+      success: true,
+      token: loginResponse.token,
+      accounts: loginResponse.data.accounts,
+      autoQcmAnswered: true,
+      autoAnswer,
+    });
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 500);
+  }
+});
+
+// Route to get the assignment notebook
+ecoleDirecteRoutes.get("/assignments/:studentId", async (c) => {
+  try {
+    const studentId = c.req.param("studentId");
+    const token = c.req.header("Authorization");
+
+    if (!token) {
+      return c.json({ error: "Authorization token missing in header" }, 401);
+    }
+
+    // Get the assignment notebook
+    const assignmentData = await ecoleDirecteService.getAssignmentNotebook(
+      Number(studentId),
+      token
+    );
+
+    return c.json(assignmentData);
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 500);
+  }
+});
+
+ecoleDirecteRoutes.get("/assignments/:studentId/:date", async (c) => {
+  try {
+    const studentId = c.req.param("studentId");
+    const date = c.req.param("date");
+    const token = c.req.header("Authorization");
+
+    if (!token) {
+      return c.json({ error: "Authorization token missing in header" }, 401);
+    }
+
+    const assignmentData = await ecoleDirecteService.getAssignmentsByDate(
+      Number(studentId),
+      token,
+      date
+    );
+
+    return c.json(assignmentData);
+  } catch (error) {
+    return c.json({ error: (error as Error).message }, 500);
+  }
+});
+
+export default ecoleDirecteRoutes;

--- a/exemple/node_hono/src/services/ecoledirecte.service.ts
+++ b/exemple/node_hono/src/services/ecoledirecte.service.ts
@@ -1,0 +1,141 @@
+import { ECOLEDIRECTE_CONFIG, ECOLEDIRECTE_URL } from "../config/constants";
+import {
+  DoubleAuthResponse,
+  EcoleDirecteResponse,
+  LoginCredentials,
+  LoginResponseData,
+  QcmQuestion,
+} from "../types/ecoleDirecte";
+import { getBaseHeaders } from "../utils/auth";
+import { extractGtkFromCookie, GtkData } from "../utils/cookies";
+import { getEndpointUrl } from "../utils/url";
+
+export class EcoleDirecteService {
+  private async request<T>(
+    endpoint: keyof typeof ECOLEDIRECTE_URL,
+    pathParams: Record<string, any> = {},
+    method: "get" | "post" | undefined = "get",
+    data: Record<string, any> = {},
+    token?: string,
+    gtkData?: GtkData,
+    queryParams?: Record<string, string | number>
+  ): Promise<EcoleDirecteResponse<T>> {
+    const form = new URLSearchParams();
+    form.append("data", JSON.stringify(data));
+
+    const response = await fetch(
+      getEndpointUrl(endpoint, pathParams, method, queryParams),
+      {
+        method: method === "get" ? "POST" : "POST",
+        headers: getBaseHeaders(gtkData, token),
+        body: form,
+      }
+    );
+
+    return response.json();
+  }
+
+  async getGTK(): Promise<GtkData> {
+    const response = await fetch(
+      getEndpointUrl("login", {}, undefined, {
+        gtk: "1",
+        v: ECOLEDIRECTE_CONFIG.apiVersion,
+      }),
+      {
+        method: "GET",
+        headers: getBaseHeaders(),
+      }
+    );
+
+    const setCookie = response.headers.get("set-cookie");
+    if (!setCookie) {
+      throw new Error("No cookie found in the response");
+    }
+
+    const gtkData = extractGtkFromCookie(setCookie);
+    if (!gtkData) {
+      throw new Error("GTK cookie not found in the response");
+    }
+
+    return gtkData;
+  }
+
+  async login(
+    gtkData: GtkData,
+    credentials: LoginCredentials
+  ): Promise<EcoleDirecteResponse<LoginResponseData>> {
+    // Map new field names to EcoleDirecte API expected names
+    const apiCredentials = {
+      identifiant: credentials.username,
+      motdepasse: credentials.password,
+      isReLogin: credentials.isReLogin,
+      uuid: credentials.uuid,
+      ...(credentials.fa && { fa: credentials.fa }),
+    };
+
+    return this.request<LoginResponseData>(
+      "login",
+      {},
+      "post",
+      apiCredentials,
+      undefined,
+      gtkData
+    );
+  }
+
+  async getQCM(
+    gtkData: GtkData,
+    token: string
+  ): Promise<EcoleDirecteResponse<QcmQuestion>> {
+    return this.request<QcmQuestion>(
+      "doubleAuth",
+      {},
+      "get",
+      {},
+      token,
+      gtkData
+    );
+  }
+
+  // Answer the QCM
+  async answerQCM(
+    gtkData: GtkData,
+    token: string,
+    choiceBase64: string
+  ): Promise<EcoleDirecteResponse<DoubleAuthResponse>> {
+    return this.request<DoubleAuthResponse>(
+      "doubleAuth",
+      {},
+      "post",
+      { choix: choiceBase64 },
+      token,
+      gtkData
+    );
+  }
+
+  async getAssignmentNotebook(studentId: number, token: string): Promise<any> {
+    const result = await this.request<any>(
+      "cahierDeTexte",
+      { eleveId: studentId },
+      "get",
+      {},
+      token
+    );
+    return result.data;
+  }
+
+  async getAssignmentsByDate(
+    studentId: number,
+    token: string,
+    date: string
+  ): Promise<any> {
+    const result = await this.request<any>(
+      "cahierDeTexteDate",
+      { eleveId: studentId, date },
+      "get",
+      {},
+      token
+    );
+    return result.data;
+  }
+}

--- a/exemple/node_hono/src/types/ecoleDirecte.ts
+++ b/exemple/node_hono/src/types/ecoleDirecte.ts
@@ -1,0 +1,53 @@
+export interface LoginCredentials {
+  username: string;
+  password: string;
+  isReLogin: boolean;
+  uuid: string;
+  fa?: Array<{ cn: string; cv: string }>;
+}
+
+export interface QcmResponse {
+  cn: string;
+  cv: string;
+}
+
+export interface EcoleDirecteResponse<T> {
+  code: number;
+  token: string;
+  message: string;
+  data: T;
+  host?: string;
+}
+
+export interface QcmQuestion {
+  question: string;
+  propositions: string[];
+}
+
+export interface Account {
+  id: number;
+  typeCompte: string;
+  nom: string;
+  prenom: string;
+  anneeScolaireCourante: string;
+  nomEtablissement: string;
+  email?: string;
+  profile?: {
+    sexe?: string;
+    classe?: {
+      id: number;
+      code: string;
+      libelle: string;
+    };
+  };
+  // Autres propriétés selon besoin
+}
+
+export interface LoginResponseData {
+  accounts: Account[];
+}
+
+export interface DoubleAuthResponse {
+  cn: string;
+  cv: string;
+}

--- a/exemple/node_hono/src/utils/auth.ts
+++ b/exemple/node_hono/src/utils/auth.ts
@@ -1,0 +1,29 @@
+import { ECOLEDIRECTE_CONFIG } from "../config/constants";
+import { GtkData } from "./cookies";
+
+export const getBaseHeaders = (gtkData?: GtkData, token?: string) => {
+  const headers: Record<string, string> = {
+    "Content-Type": "application/x-www-form-urlencoded",
+    "User-Agent": ECOLEDIRECTE_CONFIG.userAgent,
+    Accept: "application/json, text/plain, */*",
+    "Accept-Language": "fr-FR,en-US;q=0.7,en;q=0.3",
+    Origin: "https://www.ecoledirecte.com",
+    Referer: "https://www.ecoledirecte.com/",
+    DNT: "1",
+    "Sec-GPC": "1",
+    "Sec-Fetch-Dest": "empty",
+    "Sec-Fetch-Mode": "cors",
+    "Sec-Fetch-Site": "same-site",
+  };
+
+  if (gtkData) {
+    headers["Cookie"] = gtkData.cookieString;
+    headers["X-GTK"] = gtkData.gtk;
+  }
+
+  if (token) {
+    headers["X-Token"] = token;
+  }
+
+  return headers;
+};

--- a/exemple/node_hono/src/utils/base64.ts
+++ b/exemple/node_hono/src/utils/base64.ts
@@ -1,0 +1,7 @@
+export const decodeBase64 = (str: string): string => {
+  return Buffer.from(str, "base64").toString("utf-8");
+};
+
+export const encodeBase64 = (str: string): string => {
+  return Buffer.from(str).toString("base64");
+};

--- a/exemple/node_hono/src/utils/cookies.ts
+++ b/exemple/node_hono/src/utils/cookies.ts
@@ -1,0 +1,31 @@
+export interface GtkData {
+  gtk: string;
+  cookieString: string;
+}
+
+export const extractGtkFromCookie = (setCookie: string): GtkData | null => {
+  if (!setCookie) return null;
+
+  const cookieParts = setCookie.split(", ");
+  let gtkCookie = null;
+  let secondCookie = null;
+
+  for (const part of cookieParts) {
+    const cookieMain = part.split(";")[0];
+
+    if (cookieMain.startsWith("GTK=")) {
+      gtkCookie = cookieMain;
+    } else {
+      secondCookie = cookieMain;
+    }
+  }
+
+  if (!gtkCookie) return null;
+
+  const gtk = gtkCookie.substring(4);
+  const cookieString = secondCookie
+    ? `${gtkCookie}; ${secondCookie}`
+    : gtkCookie;
+
+  return { gtk, cookieString };
+};

--- a/exemple/node_hono/src/utils/qcm.ts
+++ b/exemple/node_hono/src/utils/qcm.ts
@@ -1,0 +1,39 @@
+import { QCM_ANSWERS } from "../config/qcm";
+
+export const findAnswer = (question: string): string | null => {
+  try {
+    if (!question) return null;
+
+    // Try exact match first
+    if (QCM_ANSWERS[question]) {
+      return QCM_ANSWERS[question];
+    }
+
+    // Try case-insensitive match
+    const normalizedQuestion = question.toLowerCase().trim();
+    const keys = Object.keys(QCM_ANSWERS);
+
+    for (const key of keys) {
+      if (key.toLowerCase().trim() === normalizedQuestion) {
+        return QCM_ANSWERS[key];
+      }
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error finding QCM answer:", error);
+    return null;
+  }
+};
+
+export const addAnswer = (question: string, answer: string): boolean => {
+  try {
+    if (!question || !answer) return false;
+
+    QCM_ANSWERS[question] = answer;
+    return true;
+  } catch (error) {
+    console.error("Error adding QCM answer:", error);
+    return false;
+  }
+};

--- a/exemple/node_hono/src/utils/url.ts
+++ b/exemple/node_hono/src/utils/url.ts
@@ -1,0 +1,30 @@
+import { ECOLEDIRECTE_URL } from "../config/constants";
+
+export function getEndpointUrl(
+  endpoint: keyof typeof ECOLEDIRECTE_URL,
+  params: Record<string, string | number> = {},
+  verbe: "get" | "post" | undefined = undefined,
+  queryParams: Record<string, string | number> = {}
+): string {
+  let url = ECOLEDIRECTE_URL[endpoint];
+
+  Object.entries(params).forEach(([key, value]) => {
+    url = url.replace(`{${key}}`, value.toString());
+  });
+
+  const query = new URLSearchParams();
+
+  if (verbe) {
+    query.set("verbe", verbe);
+  }
+
+  Object.entries(queryParams).forEach(([key, value]) => {
+    query.set(key, value.toString());
+  });
+
+  const queryString = query.toString();
+
+  return `${ECOLEDIRECTE_URL.baseUrl}${url}${
+    queryString ? `?${queryString}` : ""
+  }`;
+}

--- a/exemple/node_hono/tsconfig.json
+++ b/exemple/node_hono/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "strict": true,
+    "esModuleInterop": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
This example demonstrates a REST API implementation that:
- Handles EcoleDirecte API authentication, including automatic QCM security challenge resolution
- Provides endpoints to retrieve assignment notebook and homework
- Uses TypeScript and Hono for a lightweight, type-safe API
- Includes comprehensive documentation for endpoints and usage